### PR TITLE
Use geojs from npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+node_modules

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2015 Kitware Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = function (grunt) {
+
+    var path = require('path');
+
+    // This gruntfile is only designed to be used with girder's build system.
+    // Fail if grunt is executed here.
+    if (path.resolve(__dirname) === path.resolve(process.cwd())) {
+        grunt.fail.fatal('To build image_viewer, run grunt from Girder\'s root directory');
+    }
+
+    grunt.config.merge({
+        plugin: {
+            image_viewer: {
+                root: '<%= pluginDir %>/image_viewer',
+                static: '<%= staticDir %>/built/plugins/image_viewer',
+                node_modules: '<%= plugin.image_viewer.root %>/node_modules',
+                geojs: '<%= plugin.image_viewer.node_modules %>/geojs',
+                geojs_modules: '<%= plugin.image_viewer.geojs %>/node_modules',
+                geojs_components: '<%= plugin.image_viewer.geojs %>/bower_components',
+                pnltri: '<%= plugin.image_viewer.geojs_modules %>/pnltri/pnltri.js',
+                proj4: '<%= plugin.image_viewer.geojs_components %>/proj4/dist/proj4-src.js',
+                d3: '<%= plugin.image_viewer.geojs_components %>/d3/d3.js',
+                glmatrix: '<%= plugin.image_viewer.geojs_components %>/gl-matrix/gl-matrix.js'
+            }
+        },
+        uglify: {
+            'plugin-image-viewer-geojs': { // Bundle together geojs + dependencies
+                files: [
+                    {   // leaving out jquery because girder includes it
+                        src: [
+                            '<%= plugin.image_viewer.pnltri %>',
+                            '<%= plugin.image_viewer.proj4 %>',
+                            '<%= plugin.image_viewer.d3 %>',
+                            '<%= plugin.image_viewer.glmatrix %>',
+                            '<%= plugin.image_viewer.geojs %>/geo.js'
+                        ],
+                        dest: '<%= plugin.image_viewer.static %>/geo.min.js'
+                    }
+                ]
+            }
+        },
+        default: { // Tell girder about our custom tasks
+            'uglify:plugin-image-viewer-geojs': {}
+        }
+    });
+
+    // add watch tasks
+    grunt.config.merge({
+        watch: {
+            'plugin-image-viewer-geojs': {
+                files: grunt.config.getRaw('uglify.plugin-image-viewer-geojs.files')[0].src,
+                tasks: ['uglify:plugin-image-viewer-geojs']
+            }
+        }
+    });
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "girder_image_viewer",
+  "version": "1.0.0",
+  "description": "A Girder plugin to view multiresolution images, using several viewers.",
+  "homepage": "https://github.com/DigitalSlideArchive/image_viewer",
+  "bugs": {
+    "url": "https://github.com/DigitalSlideArchive/image_viewer/issues"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DigitalSlideArchive/image_viewer.git"
+  },
+  "dependencies": {
+    "geojs": "0.5.0"
+  },
+  "devDependencies": {},
+  "scripts": {}
+}

--- a/plugin.json
+++ b/plugin.json
@@ -2,5 +2,6 @@
     "name": "Image viewer",
     "description": "Large image viewers.",
     "version": "1.0.0",
-    "dependencies": ["multiresolution_image"]
+    "dependencies": ["multiresolution_image"],
+    "grunt": "Gruntfile.js"
 }

--- a/web_client/js/imageViewerWidget/geojs.js
+++ b/web_client/js/imageViewerWidget/geojs.js
@@ -2,16 +2,10 @@ girder.views.GeojsImageViewerWidget = girder.views.ImageViewerWidget.extend({
     initialize: function (settings) {
         girder.views.ImageViewerWidget.prototype.initialize.call(this, settings);
 
-        // Can't do this in parallel, dependencies must always be loaded first
         $.getScript(
-            'https://opengeoscience.github.io/geojs/built/geo.ext.min.js',
+            girder.staticRoot + '/built/plugins/image_viewer/geo.min.js',
             _.bind(function () {
-                $.getScript(
-                    'https://opengeoscience.github.io/geojs/built/geo.min.js',
-                    _.bind(function () {
-                        this.render();
-                    }, this)
-                );
+                this.render();
             }, this)
         );
 


### PR DESCRIPTION
This uses GIrder's plugin build hooks to get geojs from npm and generate a custom bundle with necessary dependencies.  To the uninitiated, the magic components here are as follows:

* The [`grunt`](https://github.com/DigitalSlideArchive/image_viewer/compare/build-geojs-npm?expand=1#diff-b3568fa08e53a00f66841ed9ca2c53d4R6) keyword in `plugin.json` tells girder to load a javascript file before executing tasks.
* The [`default`](https://github.com/DigitalSlideArchive/image_viewer/compare/build-geojs-npm?expand=1#diff-35b4a816e0441e6a375cd925af50752cR58) keyword in `grunt.config` adds a task to the "default" target
* The existence `package.json` tells Girder to do `npm install` in the plugin directory during `grunt init`.

Something similar should probably be done for the resources loaded for the other viewers as well to avoid errors that occur when the plugin is served over https.